### PR TITLE
:sparkles: Feat: Add Dockerfile.vllm to support model serving with vLLM

### DIFF
--- a/pipelines/Dockerfile.terratorch
+++ b/pipelines/Dockerfile.terratorch
@@ -52,6 +52,11 @@ RUN curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
     && mkdir -p ~/.kube \
     && chmod 700 ~/.kube
 WORKDIR /terratorch
+
+ENV HF_HOME=/app/models/huggingface_cache \
+    TERRATORCH_SEGMENTATION_IO_PROCESSOR_CONFIG='{"output_path": "/data/output/"}' \
+    PATH="/home/appuser/.local/bin:${PATH}"
+
 # Install Python dependencies with cache mount for faster rebuilds
 RUN pip install --upgrade pip && \
     pip install --timeout=7200 \
@@ -107,21 +112,27 @@ RUN mkdir -p \
 # Setup UTF-8 locale
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
-    LC_CTYPE=C.UTF-8
-# Copy application files
-COPY --chown=appuser:appuser ./components/terratorch_inference/terratorch_inference.py /opt/app-root/src/
-COPY --chown=appuser:appuser ./components/terratorch_inference/terratorch_inference_utils.py /opt/app-root/src/
-COPY --chown=appuser:appuser ./general_libraries/gfm_logger /opt/app-root/src/gfm_logger
-COPY --chown=appuser:appuser ./general_libraries/gfm_data_processing /opt/app-root/src/gfm_data_processing
-COPY --chown=appuser:appuser ./general_libraries/orchestrate_wrapper/orchestrate_wrapper.py /opt/app-root/src/
+    LC_CTYPE=C.UTF-8 \
+    # Default to Standard mode, but can be overridden to 'vllm' at runtime
+    APP_MODE=standard
 
+# Copy application files
 RUN chmod -R 777 /.cache /.config/matplotlib /opt/app-root/src/
+COPY --chown=appuser:appgroup ./components/terratorch_inference/terratorch_inference.py /opt/app-root/src/
+COPY --chown=appuser:appgroup ./components/terratorch_inference/terratorch_inference_utils.py /opt/app-root/src/
+COPY --chown=appuser:appgroup ./general_libraries/gfm_logger /opt/app-root/src/gfm_logger
+COPY --chown=appuser:appgroup ./general_libraries/gfm_data_processing /opt/app-root/src/gfm_data_processing
+COPY --chown=appuser:appgroup ./general_libraries/orchestrate_wrapper/orchestrate_wrapper.py /opt/app-root/src/
+COPY --chown=appuser:appgroup ./entrypoint.sh /app/entrypoint.sh
+COPY --chown=appuser:appgroup ./healthcheck.sh /app/healthcheck.sh
+
+RUN chmod +x /app/entrypoint.sh /app/healthcheck.sh
 
 # Switch to non-root user
 USER appuser
 WORKDIR /opt/app-root/src
-# Health check (optional but recommended)
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import terratorch; print('OK')" || exit 1
-# Default command
-CMD ["python", "/opt/app-root/src/orchestrate_wrapper.py"]
+EXPOSE 8000
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD ["/bin/bash", "/app/healthcheck.sh"]
+
+ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]

--- a/pipelines/Dockerfile.terratorch
+++ b/pipelines/Dockerfile.terratorch
@@ -52,13 +52,6 @@ RUN curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
     && mkdir -p ~/.kube \
     && chmod 700 ~/.kube
 WORKDIR /terratorch
-
-ENV HF_HOME=/app/models/huggingface_cache \
-    TERRATORCH_SEGMENTATION_IO_PROCESSOR_CONFIG='{"output_path": "/data/output/"}' \
-    PATH="/home/appuser/.local/bin:${PATH}" \
-    PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1
-
 # Install Python dependencies with cache mount for faster rebuilds
 RUN pip install --upgrade pip && \
     pip install --timeout=7200 \
@@ -114,30 +107,21 @@ RUN mkdir -p \
 # Setup UTF-8 locale
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
-    LC_CTYPE=C.UTF-8 \
-    # Default to Standard mode, but can be overridden to 'vllm' at runtime
-    APP_MODE=standard
-
+    LC_CTYPE=C.UTF-8
 # Copy application files
-RUN chmod -R 777 /.cache /.config/matplotlib /opt/app-root/src/
-COPY --chown=appuser:appgroup ./components/terratorch_inference/terratorch_inference.py /opt/app-root/src/
-COPY --chown=appuser:appgroup ./components/terratorch_inference/terratorch_inference_utils.py /opt/app-root/src/
-COPY --chown=appuser:appgroup ./general_libraries/gfm_logger /opt/app-root/src/gfm_logger
-COPY --chown=appuser:appgroup ./general_libraries/gfm_data_processing /opt/app-root/src/gfm_data_processing
-COPY --chown=appuser:appgroup ./general_libraries/orchestrate_wrapper/orchestrate_wrapper.py /opt/app-root/src/
-COPY --chown=appuser:appgroup ./entrypoint.sh /app/entrypoint.sh
-COPY --chown=appuser:appgroup ./healthcheck.sh /app/healthcheck.sh
+COPY --chown=appuser:appuser ./components/terratorch_inference/terratorch_inference.py /opt/app-root/src/
+COPY --chown=appuser:appuser ./components/terratorch_inference/terratorch_inference_utils.py /opt/app-root/src/
+COPY --chown=appuser:appuser ./general_libraries/gfm_logger /opt/app-root/src/gfm_logger
+COPY --chown=appuser:appuser ./general_libraries/gfm_data_processing /opt/app-root/src/gfm_data_processing
+COPY --chown=appuser:appuser ./general_libraries/orchestrate_wrapper/orchestrate_wrapper.py /opt/app-root/src/
 
-RUN chmod +x /app/entrypoint.sh /app/healthcheck.sh
+RUN chmod -R 777 /.cache /.config/matplotlib /opt/app-root/src/
 
 # Switch to non-root user
 USER appuser
-
 WORKDIR /opt/app-root/src
-
-EXPOSE 8000
-
-HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD ["/bin/bash", "/app/healthcheck.sh"]
-
-ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]
+# Health check (optional but recommended)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python -c "import terratorch; print('OK')" || exit 1
+# Default command
+CMD ["python", "/opt/app-root/src/orchestrate_wrapper.py"]

--- a/pipelines/Dockerfile.terratorch
+++ b/pipelines/Dockerfile.terratorch
@@ -55,7 +55,9 @@ WORKDIR /terratorch
 
 ENV HF_HOME=/app/models/huggingface_cache \
     TERRATORCH_SEGMENTATION_IO_PROCESSOR_CONFIG='{"output_path": "/data/output/"}' \
-    PATH="/home/appuser/.local/bin:${PATH}"
+    PATH="/home/appuser/.local/bin:${PATH}" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
 
 # Install Python dependencies with cache mount for faster rebuilds
 RUN pip install --upgrade pip && \
@@ -130,8 +132,11 @@ RUN chmod +x /app/entrypoint.sh /app/healthcheck.sh
 
 # Switch to non-root user
 USER appuser
+
 WORKDIR /opt/app-root/src
+
 EXPOSE 8000
+
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
     CMD ["/bin/bash", "/app/healthcheck.sh"]
 

--- a/pipelines/Dockerfile.vllm
+++ b/pipelines/Dockerfile.vllm
@@ -1,0 +1,88 @@
+################################################################################
+# Build Arguments
+################################################################################
+ARG CUDA_VERSION=13.1.1
+
+################################################################################
+# Stage 1: Builder
+################################################################################
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu24.04 AS builder
+
+ARG PYTHON_VERSION=3.11 \
+    VLLM_VERSION=0.17.1
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    CUDA_HOME=/usr/local/cuda
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-venv \
+    python3-dev \
+    git \
+    curl \
+    build-essential \
+    gdal-bin \
+    libgdal-dev \
+    libproj-dev \
+    libgeos-dev \
+    libspatialindex-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    pip install --no-cache-dir torch==2.4.0 --index-url https://download.pytorch.org/whl/cu121 && \
+    pip install --no-cache-dir vllm==${VLLM_VERSION} "terratorch[vllm]" GDAL==$(gdal-config --version)
+
+RUN find /opt/venv -type d -name "tests" -exec rm -rf {} + && \
+    find /opt/venv -type d -name "__pycache__" -exec rm -rf {} + && \
+    find /opt/venv -name "*.a" -delete && \
+    find /opt/venv -name "*.pyc" -delete && \
+    find /opt/venv -name "*.so" -exec strip --strip-unneeded {} +
+
+################################################################################
+# Stage 2: Runtime
+################################################################################
+FROM nvidia/cuda:${CUDA_VERSION}-base-ubuntu24.04 AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-minimal \
+    libgomp1 \
+    libgdal34 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+ENV UID=10001 \
+    USER=appuser
+
+RUN groupadd -g ${UID} -r ${USER} && \
+    useradd -l -u ${UID} -r -g ${USER} ${USER} -ms /bin/bash && \
+    mkdir -p /app/models/huggingface_cache/hub /data/output && \
+    chown -R ${USER}:${USER} /app /data
+
+ENV HF_HOME=/app/models/huggingface_cache \
+    TERRATORCH_SEGMENTATION_IO_PROCESSOR_CONFIG='{"output_path": "/data/output/"}' \
+    GDAL_CONFIG=/usr/bin/gdal-config \
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8
+
+WORKDIR /app
+
+COPY --chown=${USER}:${USER} ./entrypoint.sh /app/entrypoint.sh
+COPY --chown=${USER}:${USER} ./healthcheck.sh /app/healthcheck.sh
+RUN chmod +x /app/entrypoint.sh /app/healthcheck.sh
+
+USER ${USER}
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=180s --retries=3 \
+    CMD ["/bin/bash", "/app/healthcheck.sh"]
+
+ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]

--- a/pipelines/Dockerfile.vllm
+++ b/pipelines/Dockerfile.vllm
@@ -2,23 +2,24 @@
 # Build Arguments
 ################################################################################
 ARG CUDA_VERSION=13.1.1
+ARG PYTHON_VERSION=3.12
 
 ################################################################################
 # Stage 1: Builder
 ################################################################################
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu24.04 AS builder
 
-ARG PYTHON_VERSION=3.11 \
-    VLLM_VERSION=0.17.1
+ARG PYTHON_VERSION
+ARG VLLM_VERSION=0.17.1
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     CUDA_HOME=/usr/local/cuda
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 \
-    python3-venv \
-    python3-dev \
+    python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-venv \
+    python${PYTHON_VERSION}-dev \
     git \
     curl \
     build-essential \
@@ -30,7 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-RUN python3 -m venv /opt/venv
+RUN python${PYTHON_VERSION} -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 RUN --mount=type=cache,target=/root/.cache/pip \
@@ -38,19 +39,17 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --no-cache-dir torch==2.4.0 --index-url https://download.pytorch.org/whl/cu121 && \
     pip install --no-cache-dir vllm==${VLLM_VERSION} "terratorch[vllm]" GDAL==$(gdal-config --version)
 
-RUN find /opt/venv -type d -name "tests" -exec rm -rf {} + && \
-    find /opt/venv -type d -name "__pycache__" -exec rm -rf {} + && \
-    find /opt/venv -name "*.a" -delete && \
-    find /opt/venv -name "*.pyc" -delete && \
-    find /opt/venv -name "*.so" -exec strip --strip-unneeded {} +
-
 ################################################################################
 # Stage 2: Runtime
 ################################################################################
 FROM nvidia/cuda:${CUDA_VERSION}-base-ubuntu24.04 AS runtime
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3-minimal \
+ARG PYTHON_VERSION
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-dev \
+    python${PYTHON_VERSION}-venv \
     libgomp1 \
     libgdal34 \
     && rm -rf /var/lib/apt/lists/*
@@ -64,11 +63,16 @@ ENV UID=10001 \
 RUN groupadd -g ${UID} -r ${USER} && \
     useradd -l -u ${UID} -r -g ${USER} ${USER} -ms /bin/bash && \
     mkdir -p /app/models/huggingface_cache/hub /data/output && \
-    chown -R ${USER}:${USER} /app /data
+    chown -R ${USER}:${USER} /app /data && \
+    chmod -R g=u /app /data
 
 ENV HF_HOME=/app/models/huggingface_cache \
     TERRATORCH_SEGMENTATION_IO_PROCESSOR_CONFIG='{"output_path": "/data/output/"}' \
     GDAL_CONFIG=/usr/bin/gdal-config \
+    HOME=/app \
+    MPLCONFIGDIR=/app/.config/matplotlib \
+    XDG_CACHE_HOME=/app/.cache \
+    XDG_CONFIG_HOME=/app/.config \
     LC_ALL=C.UTF-8 \
     LANG=C.UTF-8
 

--- a/pipelines/entrypoint.sh
+++ b/pipelines/entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -e
 
-if [ "$APP_MODE" = "v" ]; then
-    echo "Starting in Standard TerraTorch mode..."
+if [ "$APP_MODE" = "vllm" ]; then
+    echo "Starting in VLLM mode"
 
     MODEL_NAME=${MODEL_NAME:-"ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11"}
     PLUGIN_NAME=${PLUGIN_NAME:-"terratorch_segmentation"}
-    HF_HOME=${HF_HOME:-"/workspace/models/huggingface_cache"}
+    HF_HOME=${HF_HOME:-"/app/models/huggingface_cache"}
 
     echo "=========================================="
     echo "vLLM Prithvi Flood Detection Server"
@@ -18,8 +18,8 @@ if [ "$APP_MODE" = "v" ]; then
     echo ""
     # 1. Clear Hugging Face lock files
     # This prevents the 'OSError: PermissionError' if a previous pod crashed
-    echo "Checking for stale lock files in /workspace/models..."
-    find /workspace/models -name "*.lock" -delete
+    echo "Checking for stale lock files in /app/models..."
+    find /app/models -name "*.lock" -delete
 
     # 2. Verify GPU availability
     # This logs the GPU status to help debug 'Pending' or 'Runtime' errors

--- a/pipelines/entrypoint.sh
+++ b/pipelines/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+if [ "$APP_MODE" = "v" ]; then
+    echo "Starting in Standard TerraTorch mode..."
+
+    MODEL_NAME=${MODEL_NAME:-"ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11"}
+    PLUGIN_NAME=${PLUGIN_NAME:-"terratorch_segmentation"}
+    HF_HOME=${HF_HOME:-"/workspace/models/huggingface_cache"}
+
+    echo "=========================================="
+    echo "vLLM Prithvi Flood Detection Server"
+    echo "=========================================="
+    echo "Model: $MODEL_NAME"
+    echo "Plugin: $PLUGIN_NAME"
+    echo "Cache: $HF_HOME"
+    echo "=========================================="
+    echo ""
+    # 1. Clear Hugging Face lock files
+    # This prevents the 'OSError: PermissionError' if a previous pod crashed
+    echo "Checking for stale lock files in /workspace/models..."
+    find /workspace/models -name "*.lock" -delete
+
+    # 2. Verify GPU availability
+    # This logs the GPU status to help debug 'Pending' or 'Runtime' errors
+    echo ""
+    if command -v nvidia-smi &> /dev/null; then
+        echo "GPU detected:"
+        nvidia-smi --query-gpu=name,memory.total,utilization.gpu --format=csv
+    else
+        echo "WARNING: nvidia-smi not found. GPU may not be accessible."
+    fi
+    echo ""
+    echo "Downloading model (first run may take several minutes)..."
+    vllm serve "$MODEL_NAME" \
+        --model-impl terratorch \
+        --runner pooling \
+        --convert embed \
+        --trust-remote-code \
+        --skip-tokenizer-init \
+        --enforce-eager \
+        --io-processor-plugin "$PLUGIN_NAME" \
+        --enable-mm-embeds \
+        --host 0.0.0.0 \
+        --port 8000 \
+        --dtype float16 \
+        --gpu-memory-utilization 0.7 \
+        --max-model-len 2048 \
+        --max-num-seqs 4
+
+else
+    echo "Starting in Standard TerraTorch mode..."
+    exec python /opt/app-root/src/orchestrate_wrapper.py
+
+fi

--- a/pipelines/entrypoint.sh
+++ b/pipelines/entrypoint.sh
@@ -1,55 +1,48 @@
 #!/bin/bash
 set -e
 
-if [ "$APP_MODE" = "vllm" ]; then
-    echo "Starting in VLLM mode"
+echo "Starting in VLLM mode"
 
-    MODEL_NAME=${MODEL_NAME:-"ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11"}
-    PLUGIN_NAME=${PLUGIN_NAME:-"terratorch_segmentation"}
-    HF_HOME=${HF_HOME:-"/app/models/huggingface_cache"}
+MODEL_NAME=${MODEL_NAME:-"ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11"}
+PLUGIN_NAME=${PLUGIN_NAME:-"terratorch_segmentation"}
+HF_HOME=${HF_HOME:-"/app/models/huggingface_cache"}
 
-    echo "=========================================="
-    echo "vLLM Prithvi Flood Detection Server"
-    echo "=========================================="
-    echo "Model: $MODEL_NAME"
-    echo "Plugin: $PLUGIN_NAME"
-    echo "Cache: $HF_HOME"
-    echo "=========================================="
-    echo ""
-    # 1. Clear Hugging Face lock files
-    # This prevents the 'OSError: PermissionError' if a previous pod crashed
-    echo "Checking for stale lock files in /app/models..."
-    find /app/models -name "*.lock" -delete
+echo "=========================================="
+echo "vLLM Prithvi Flood Detection Server"
+echo "=========================================="
+echo "Model: $MODEL_NAME"
+echo "Plugin: $PLUGIN_NAME"
+echo "Cache: $HF_HOME"
+echo "=========================================="
+echo ""
+# 1. Clear Hugging Face lock files
+# This prevents the 'OSError: PermissionError' if a previous pod crashed
+echo "Checking for stale lock files in /app/models..."
+find /app/models -name "*.lock" -delete
 
-    # 2. Verify GPU availability
-    # This logs the GPU status to help debug 'Pending' or 'Runtime' errors
-    echo ""
-    if command -v nvidia-smi &> /dev/null; then
-        echo "GPU detected:"
-        nvidia-smi --query-gpu=name,memory.total,utilization.gpu --format=csv
-    else
-        echo "WARNING: nvidia-smi not found. GPU may not be accessible."
-    fi
-    echo ""
-    echo "Downloading model (first run may take several minutes)..."
-    vllm serve "$MODEL_NAME" \
-        --model-impl terratorch \
-        --runner pooling \
-        --convert embed \
-        --trust-remote-code \
-        --skip-tokenizer-init \
-        --enforce-eager \
-        --io-processor-plugin "$PLUGIN_NAME" \
-        --enable-mm-embeds \
-        --host 0.0.0.0 \
-        --port 8000 \
-        --dtype float16 \
-        --gpu-memory-utilization 0.7 \
-        --max-model-len 2048 \
-        --max-num-seqs 4
-
+# 2. Verify GPU availability
+# This logs the GPU status to help debug 'Pending' or 'Runtime' errors
+echo ""
+if command -v nvidia-smi &> /dev/null; then
+    echo "GPU detected:"
+    nvidia-smi --query-gpu=name,memory.total,utilization.gpu --format=csv
 else
-    echo "Starting in Standard TerraTorch mode..."
-    exec python /opt/app-root/src/orchestrate_wrapper.py
-
+    echo "WARNING: nvidia-smi not found. GPU may not be accessible."
 fi
+echo ""
+echo "Downloading model (first run may take several minutes)..."
+vllm serve "$MODEL_NAME" \
+    --model-impl terratorch \
+    --runner pooling \
+    --convert embed \
+    --trust-remote-code \
+    --skip-tokenizer-init \
+    --enforce-eager \
+    --io-processor-plugin "$PLUGIN_NAME" \
+    --enable-mm-embeds \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --dtype float16 \
+    --gpu-memory-utilization 0.7 \
+    --max-model-len 2048 \
+    --max-num-seqs 4

--- a/pipelines/healthcheck.sh
+++ b/pipelines/healthcheck.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$APP_MODE" = "vllm" ]; then
+    # vLLM healthcheck: check the web endpoint
+    curl -f http://localhost:8000/health || exit 1
+else
+    # TerraTorch healthcheck: check if the package is importable/functional
+    python -c "import terratorch; print('OK')" || exit 1
+fi

--- a/pipelines/healthcheck.sh
+++ b/pipelines/healthcheck.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 
-if [ "$APP_MODE" = "vllm" ]; then
-    # vLLM healthcheck: check the web endpoint
-    curl -f http://localhost:8000/health || exit 1
+set -e
+
+PORT=${PORT:-8000}
+HOST=${HOST:-"localhost"}
+HEALTH_URL="http://${HOST}:${PORT}/health"
+
+# Try to get health status
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_URL" 2>/dev/null || echo "000")
+
+if [ "$HTTP_CODE" = "200" ]; then
+    echo "vLLM server is healthy (HTTP $HTTP_CODE)"
+    exit 0
 else
-    # TerraTorch healthcheck: check if the package is importable/functional
-    python -c "import terratorch; print('OK')" || exit 1
+    echo "vLLM server health check failed (HTTP $HTTP_CODE)"
+    exit 1
 fi


### PR DESCRIPTION
## Summary

Add Dockerfile.vllm to support model serving with vLLM

## Related Issue (optional)

<!-- e.g. Fixes #123 -->

## How to test this PR?

1. Port-forward to deployed pod:
   `kubectl port-forward -n geospatial-dev deployment/vllm-geospatial-studio 8000:8000`

2. Send POST request to /pooling endpoint:
```
   {
       "data": {
           "data": "https://ibm.box.com/shared/static/orraqbi379pwfpvjaurufddfj2qjftly.tif",
           "data_format": "url",
           "out_data_format": "path",
           "out_path": "/data/f32cb5c9-6c6b-426d-8feb-a901bf55a411/f32cb5c9-6c6b-426d-8feb-a901bf55a411-task_0",
           "image_format": "tiff"
       },
       "model": "ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11"
   }
```

## Screenshots / Logs (optional)

<!-- Attach any relevant logs or screenshots. -->

## Checklist

- [x] This PR targets the main branch
- [ ] I have added or updated relevant docs.
- [x] I have not included any secrets or credentials.
- [ ] Linting and formatting checks pass.
