### PR TITLE
FIX include shapefile companion extensions in archive zip

### DIFF
--- a/pipelines/components/postprocess-generic-single/postprocess_generic_helper_functions.py
+++ b/pipelines/components/postprocess-generic-single/postprocess_generic_helper_functions.py
@@ -423,7 +423,7 @@ def zip_inference_data(task_dir):
     zip_location = f"{task_dir}/archive.zip"
 
     directory = Path(task_dir)
-    geoserver_supported_extensions = ("*.tif", "*.gpkg", "*.shp", "*.nc")
+    geoserver_supported_extensions = ("*.tif", "*.gpkg", "*.shp", "*.shx", "*.dbf", "*.cpg", "*.prj", "*.nc")
 
     with ZipFile(zip_location, mode="w") as archive:
         for file_path in chain.from_iterable(directory.glob(ext) for ext in geoserver_supported_extensions):


### PR DESCRIPTION
Closes #32

## What changed
Added missing shapefile companion extensions (`.shx`, `.dbf`, `.cpg`, `.prj`) 
to `geoserver_supported_extensions` in `zip_inference_data()`.

## Before
Only `.shp` was included in archive.zip, making the shapefile invalid.

## After
All required shapefile extensions are now zipped together.
