### PR TITLE
fix: include shapefile companion files in archive zip

### DIFF
--- a/pipelines/components/push_to_geoserver/push_to_geoserver_helper_functions.py
+++ b/pipelines/components/push_to_geoserver/push_to_geoserver_helper_functions.py
@@ -153,7 +153,15 @@ def add_vector_to_geoserver(geo, workspace, file_path, layer_name, store_format)
     if store_format == "gpkg":
         zip_file_path = pack_files_in_zip(file_paths=[file_path], store_name=layer_name)
     elif store_format == "shp":
-        zip_file_path = file_path
+        # Shapefiles require companion files (.shx, .dbf, .prj, .cpg)
+        shp_base = os.path.splitext(file_path)[0]
+        companion_exts = [".shp", ".shx", ".dbf", ".prj", ".cpg"]
+        companion_files = []
+        for ext in companion_exts:
+            companion = shp_base + ext
+            if os.path.exists(companion):
+                companion_files.append(companion)
+        zip_file_path = pack_files_in_zip(file_paths=companion_files, store_name=layer_name)
 
     create_genericstore(
         geo=geo,


### PR DESCRIPTION
Fixes #32

## Problem
When saving `.shp` files, the archive zip only contained the `.shp` file. Shapefiles require companion files (`.shx`, `.dbf`, `.prj`, `.cpg`) to be valid and loadable by GIS software like GeoServer.

## Fix
When `store_format == "shp"`, the code now:
1. Discovers all companion files by checking for `.shx`, `.dbf`, `.prj`, `.cpg` alongside the `.shp`
2. Zips all existing companion files together (only including files that actually exist)
3. Passes the zip to GeoServer instead of the bare `.shp` file

This matches the existing pattern for gpkg files (which also use `pack_files_in_zip`).