### PR TITLE
chore: :wrench: fix 🩹  before_sleep_log expects integer instead of string

### DIFF
--- a/pipelines/components/terrakit_data_fetch/terrakit_data_fetch.py
+++ b/pipelines/components/terrakit_data_fetch/terrakit_data_fetch.py
@@ -12,6 +12,7 @@ The TerraKit process will query data from a range of different data connectors
 import os
 import json
 import numpy as np
+import logging
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -60,7 +61,7 @@ def s1grd_to_decibels(da, modality_tag):
     stop=stop_after_attempt(3),
     wait=wait_fixed(5),
     retry=retry_if_exception_type((RuntimeError, ConnectionError, OSError)),
-    before_sleep=before_sleep_log(logger, "WARNING"),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
     reraise=True,
 )
 def fetch_data_with_retry(dc, collection_name, data_date, bbox, maxcc, band_names, save_filepath, task_folder):


### PR DESCRIPTION
## Summary

🐛 in terrakit data fetch, data fetch broken; expected value in before_sleep_log is an integer

## Related Issue (optional)

Related to https://github.com/terrastackai/geospatial-studio-core/pull/39

## Checklist

- [ ] This PR targets the main branch
- [ ] I have added or updated relevant docs.
- [ ] I have not included any secrets or credentials.
- [ ] Linting and formatting checks pass.
