### PR TITLE
Add group-based artifact sharing system

### DIFF
--- a/gfmstudio/db_migrations/env.py
+++ b/gfmstudio/db_migrations/env.py
@@ -30,6 +30,7 @@ if config.config_file_name is not None:
 
 from gfmstudio.common.db import Base  # noqa: E402
 from gfmstudio.fine_tuning.models import *  # noqa: F401 E402 F403
+from gfmstudio.groups.models import *  # noqa: F401 E402 F403
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/gfmstudio/db_migrations/versions/a1b2c3d4e5f6_add_groups_and_artifact_permissions.py
+++ b/gfmstudio/db_migrations/versions/a1b2c3d4e5f6_add_groups_and_artifact_permissions.py
@@ -29,8 +29,8 @@ def upgrade() -> None:
         "SELECT 1 FROM pg_type WHERE typname = 'group_role'"
     )).fetchone()
     if not result:
-        group_role_enum = postgresql.ENUM("owner", "member", name="group_role")
-        group_role_enum.create(conn)
+        group_role_enum = postgresql.ENUM("owner", "member", name="group_role", create_type=False)
+        group_role_enum.create(conn, checkfirst=True)
     
     # Check and create artifact_type_enum
     result = conn.execute(sa.text(
@@ -45,8 +45,9 @@ def upgrade() -> None:
             "task_template",
             "inference_run",
             name="artifact_type_enum",
+            create_type=False,
         )
-        artifact_type_enum.create(conn)
+        artifact_type_enum.create(conn, checkfirst=True)
 
     # Create groups table
     op.create_table(
@@ -72,7 +73,7 @@ def upgrade() -> None:
         sa.Column("user_email", sa.String(length=255), nullable=False),
         sa.Column(
             "role",
-            postgresql.ENUM("owner", "member", name="group_role"),
+            postgresql.ENUM("owner", "member", name="group_role", create_type=False),
             nullable=False,
             server_default="member",
         ),
@@ -108,6 +109,7 @@ def upgrade() -> None:
                 "task_template",
                 "inference_run",
                 name="artifact_type_enum",
+                create_type=False,
             ),
             nullable=False,
         ),

--- a/gfmstudio/db_migrations/versions/a1b2c3d4e5f6_add_groups_and_artifact_permissions.py
+++ b/gfmstudio/db_migrations/versions/a1b2c3d4e5f6_add_groups_and_artifact_permissions.py
@@ -1,0 +1,163 @@
+# © Copyright IBM Corporation 2025
+# SPDX-License-Identifier: Apache-2.0
+
+
+"""add groups and artifact permissions
+
+Revision ID: a1b2c3d4e5f6
+Revises: 9f02b7f65a7d
+Create Date: 2026-03-12 17:59:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "9f02b7f65a7d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create ENUM types only if they don't exist
+    conn = op.get_bind()
+    
+    # Check and create group_role enum
+    result = conn.execute(sa.text(
+        "SELECT 1 FROM pg_type WHERE typname = 'group_role'"
+    )).fetchone()
+    if not result:
+        group_role_enum = postgresql.ENUM("owner", "member", name="group_role")
+        group_role_enum.create(conn)
+    
+    # Check and create artifact_type_enum
+    result = conn.execute(sa.text(
+        "SELECT 1 FROM pg_type WHERE typname = 'artifact_type_enum'"
+    )).fetchone()
+    if not result:
+        artifact_type_enum = postgresql.ENUM(
+            "dataset",
+            "tune",
+            "backbone",
+            "model",
+            "task_template",
+            "inference_run",
+            name="artifact_type_enum",
+        )
+        artifact_type_enum.create(conn)
+
+    # Create groups table
+    op.create_table(
+        "groups",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_by", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+
+    # Create group_members table
+    op.create_table(
+        "group_members",
+        sa.Column("group_id", sa.UUID(), nullable=False),
+        sa.Column("user_email", sa.String(length=255), nullable=False),
+        sa.Column(
+            "role",
+            postgresql.ENUM("owner", "member", name="group_role"),
+            nullable=False,
+            server_default="member",
+        ),
+        sa.Column(
+            "added_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["group_id"],
+            ["groups.id"],
+            name="fk_group_members_group_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("group_id", "user_email"),
+    )
+    op.create_index(
+        "ix_group_members_user_email", "group_members", ["user_email"], unique=False
+    )
+
+    # Create artifact_permissions table
+    op.create_table(
+        "artifact_permissions",
+        sa.Column("group_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "artifact_type",
+            postgresql.ENUM(
+                "dataset",
+                "tune",
+                "backbone",
+                "model",
+                "task_template",
+                "inference_run",
+                name="artifact_type_enum",
+            ),
+            nullable=False,
+        ),
+        sa.Column("artifact_id", sa.UUID(), nullable=False),
+        sa.Column("granted_by", sa.String(length=255), nullable=False),
+        sa.Column(
+            "granted_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["group_id"],
+            ["groups.id"],
+            name="fk_artifact_permissions_group_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("group_id", "artifact_type", "artifact_id"),
+    )
+    op.create_index(
+        "ix_artifact_permissions_artifact",
+        "artifact_permissions",
+        ["artifact_type", "artifact_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    # Drop tables in reverse order
+    op.drop_index("ix_artifact_permissions_artifact", table_name="artifact_permissions")
+    op.drop_table("artifact_permissions")
+
+    op.drop_index("ix_group_members_user_email", table_name="group_members")
+    op.drop_table("group_members")
+
+    op.drop_table("groups")
+
+    # Drop ENUM types
+    artifact_type_enum = postgresql.ENUM(
+        "dataset",
+        "tune",
+        "backbone",
+        "model",
+        "task_template",
+        "inference_run",
+        name="artifact_type_enum",
+    )
+    artifact_type_enum.drop(op.get_bind())
+
+    group_role_enum = postgresql.ENUM("owner", "member", name="group_role")
+    group_role_enum.drop(op.get_bind())
+
+# Made with Bob

--- a/gfmstudio/fine_tuning/api.py
+++ b/gfmstudio/fine_tuning/api.py
@@ -30,7 +30,7 @@ from fastapi import (
 )
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
-from sqlalchemy import and_, literal_column
+from sqlalchemy import and_, literal_column, or_
 from sqlalchemy.orm import Session
 
 from gfmstudio.auth import authorizer
@@ -68,6 +68,8 @@ from gfmstudio.fine_tuning.utils.dataset_handlers import (
 )
 from gfmstudio.fine_tuning.utils.tune_handlers import get_rendered_tuning_template
 from gfmstudio.fine_tuning.utils.webhook_event_handlers import upload_logs_cos
+from gfmstudio.groups.models import ArtifactType
+from gfmstudio.groups.visibility import build_visibility_filter
 from gfmstudio.inference.v2.models import Inference
 from gfmstudio.inference.v2.models import Model as InferenceModel
 from gfmstudio.inference.v2.schemas import InferenceCreateInput, InferenceGetResponse
@@ -406,26 +408,25 @@ async def list_tunes(
     user = auth[0]
     qp_filters = {}
     search_filters = {}
-    ignore_user_check = False
+    filter_expr = None
     if name:
         search_filters["name"] = name
     if status:
         qp_filters["status"] = status
-    if shared is not None:
-        # TODO: Add logic to mark tunes as sharable and update this filter
-        # we currently assume that for a tune to be shared it was
-        # created_by the system user.
-        qp_filters["created_by"] = settings.DEFAULT_SYSTEM_USER if shared else user
-        ignore_user_check = True
+    
+    # Apply group-based visibility filter
+    visibility_filter = build_visibility_filter(Tunes, user, ArtifactType.tune, db)
+    filter_expr = visibility_filter
 
     count, items = tunes_crud.get_all(
         db=db,
         filters=qp_filters,
         search=search_filters,
+        filter_expr=filter_expr,
         limit=limit,
         skip=skip,
         user=user,
-        ignore_user_check=ignore_user_check,
+        ignore_user_check=True,
         total_count=True,
     )
     return {"results": items, "total_records": count}
@@ -467,7 +468,9 @@ async def retrieve_tune(
         404: Tune not Found
     """
     user = auth[0]
-    item = tunes_crud.get_by_id(db=db, item_id=tune_id, user=user)
+    # Check visibility using group-based filter
+    visibility_filter = build_visibility_filter(Tunes, user, ArtifactType.tune, db)
+    item = db.query(Tunes).filter(and_(Tunes.id == tune_id, visibility_filter)).first()
     if not item:
         raise HTTPException(status_code=404, detail="Tune not found")
 
@@ -1348,9 +1351,7 @@ async def get_bases(
     user = auth[0]
     qp_filters = {}
     search_filters = {}
-    filter_expr = None
     filter_expr_list = []
-    ignore_user_check = False
     if name:
         search_filters["name"] = name
     if status:
@@ -1360,14 +1361,12 @@ async def get_bases(
             BaseModels.model_params["model_category"].astext
             == str(model_category).lower()
         )
-    if shared is not None:
-        # TODO: Add logic to mark tunes as sharable and update this filter
-        # we currently assume that for a tune to be shared it was
-        # created_by the system user.
-        qp_filters["created_by"] = settings.DEFAULT_SYSTEM_USER if shared else user
-        ignore_user_check = True
-    if filter_expr_list:
-        filter_expr = and_(*filter_expr_list)
+    
+    # Apply group-based visibility filter
+    visibility_filter = build_visibility_filter(BaseModels, user, ArtifactType.backbone, db)
+    filter_expr_list.append(visibility_filter)
+    
+    filter_expr = and_(*filter_expr_list) if filter_expr_list else None
     count, items = bases_crud.get_all(
         db=db,
         filters=qp_filters,
@@ -1376,7 +1375,7 @@ async def get_bases(
         limit=limit,
         skip=skip,
         user=user,
-        ignore_user_check=ignore_user_check,
+        ignore_user_check=True,
         total_count=True,
     )
     return {"results": items, "total_records": count}
@@ -1555,17 +1554,22 @@ async def list_tune_templates(
     user = auth[0]
     qp_filters = {}
     search_filters = {}
-    filter_expr = None
+    filter_expr_list = []
     if name:
         search_filters["name"] = name
     if model_category:
-        filter_expr = (
+        filter_expr_list.append(
             TuneTemplate.extra_info["model_category"].astext
             == str(model_category).lower()
         )
     if purpose:
         qp_filters["purpose"] = purpose
 
+    # Apply group-based visibility filter
+    visibility_filter = build_visibility_filter(TuneTemplate, user, ArtifactType.task_template, db)
+    filter_expr_list.append(visibility_filter)
+    
+    filter_expr = and_(*filter_expr_list) if filter_expr_list else None
     count, items = tune_template_crud.get_all(
         db=db,
         filters=qp_filters,
@@ -1574,6 +1578,7 @@ async def list_tune_templates(
         limit=limit,
         skip=skip,
         user=user,
+        ignore_user_check=True,
         total_count=True,
     )
     return {"results": items, "total_records": count}
@@ -1667,7 +1672,9 @@ async def retrieve_task(
         404: Task not found
     """
     user = auth[0]
-    task = tune_template_crud.get_by_id(db=db, item_id=task_id, user=user)
+    # Check visibility using group-based filter
+    visibility_filter = build_visibility_filter(TuneTemplate, user, ArtifactType.task_template, db)
+    task = db.query(TuneTemplate).filter(and_(TuneTemplate.id == task_id, visibility_filter)).first()
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
 
@@ -1979,19 +1986,24 @@ async def list_datasets(
 ):
     user = auth[0]
     filter_fields = {"version": "v2"}
-    filter_expr = None
+    filter_expr_list = []
     search_filters = {}
     if dataset_name:
         search_filters["dataset_name"] = dataset_name
     if purpose:
-        filter_expr = GeoDataset.purpose.in_(purpose)
+        filter_expr_list.append(GeoDataset.purpose.in_(purpose))
     if status:
         filter_fields["status"] = status
 
+    # Apply group-based visibility filter
+    visibility_filter = build_visibility_filter(GeoDataset, user, ArtifactType.dataset, db)
+    filter_expr_list.append(visibility_filter)
+    
+    filter_expr = and_(*filter_expr_list) if filter_expr_list else None
     count, items = dataset_crud.get_all(
         db,
         user=user,
-        ignore_user_check=False,
+        ignore_user_check=True,
         limit=limit,
         skip=skip,
         filters=filter_fields,

--- a/gfmstudio/groups/__init__.py
+++ b/gfmstudio/groups/__init__.py
@@ -1,0 +1,4 @@
+# © Copyright IBM Corporation 2025
+# SPDX-License-Identifier: Apache-2.0
+
+# Made with Bob

--- a/gfmstudio/groups/api.py
+++ b/gfmstudio/groups/api.py
@@ -1,0 +1,695 @@
+# © Copyright IBM Corporation 2025
+# SPDX-License-Identifier: Apache-2.0
+
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import and_, func
+from sqlalchemy.orm import Session
+
+from gfmstudio.auth.authorizer import auth_handler
+from gfmstudio.common.api import utils
+from gfmstudio.fine_tuning.models import BaseModels, GeoDataset, Tunes, TuneTemplate
+from gfmstudio.groups.models import (
+    ArtifactPermission,
+    ArtifactType,
+    Group,
+    GroupMember,
+    GroupRole,
+)
+from gfmstudio.groups.schemas import (
+    ArtifactPermissionGrant,
+    ArtifactPermissionOut,
+    GroupCreate,
+    GroupMemberAdd,
+    GroupOut,
+    MemberRoleUpdate,
+)
+from gfmstudio.inference.v2.models import Inference, Model
+
+router = APIRouter(prefix="/groups", tags=["Groups"])
+
+# Mapping of artifact types to their SQLAlchemy model classes
+ARTIFACT_TYPE_TO_MODEL = {
+    ArtifactType.dataset: GeoDataset,
+    ArtifactType.tune: Tunes,
+    ArtifactType.backbone: BaseModels,
+    ArtifactType.model: Model,
+    ArtifactType.task_template: TuneTemplate,
+    ArtifactType.inference_run: Inference,
+}
+
+
+def _require_group_owner(group_id: UUID, user_email: str, db: Session) -> GroupMember:
+    """
+    Helper function to verify that a user is an owner of a group.
+
+    Parameters
+    ----------
+    group_id : UUID
+        The group ID to check
+    user_email : str
+        The user's email address
+    db : Session
+        Database session
+
+    Returns
+    -------
+    GroupMember
+        The group member record if user is an owner
+
+    Raises
+    ------
+    HTTPException
+        403 if user is not an owner of the group
+    """
+    member = (
+        db.query(GroupMember)
+        .filter(
+            and_(
+                GroupMember.group_id == group_id,
+                GroupMember.user_email == user_email,
+            )
+        )
+        .first()
+    )
+
+    if not member or member.role != GroupRole.owner:
+        raise HTTPException(
+            status_code=403,
+            detail="Only group owners can perform this action",
+        )
+
+    return member
+
+
+def _require_group_member(group_id: UUID, user_email: str, db: Session) -> GroupMember:
+    """
+    Helper function to verify that a user is a member of a group.
+
+    Parameters
+    ----------
+    group_id : UUID
+        The group ID to check
+    user_email : str
+        The user's email address
+    db : Session
+        Database session
+
+    Returns
+    -------
+    GroupMember
+        The group member record
+
+    Raises
+    ------
+    HTTPException
+        403 if user is not a member of the group
+    """
+    member = (
+        db.query(GroupMember)
+        .filter(
+            and_(
+                GroupMember.group_id == group_id,
+                GroupMember.user_email == user_email,
+            )
+        )
+        .first()
+    )
+
+    if not member:
+        raise HTTPException(
+            status_code=403,
+            detail="You must be a member of this group to perform this action",
+        )
+
+    return member
+
+
+# ***************************************************
+# Group Management
+# ***************************************************
+@router.post("/", response_model=GroupOut, status_code=201)
+async def create_group(
+    group: GroupCreate,
+    db: Session = Depends(utils.get_db),
+    auth=Depends(auth_handler),
+):
+    """
+    Create a new group. The creator is automatically added as an owner.
+
+    Parameters
+    ----------
+    group : GroupCreate
+        Group creation data
+    db : Session
+        Database session
+    auth : tuple
+        Authentication tuple (email, token, groups)
+
+    Returns
+    -------
+    GroupOut
+        The created group with members
+    """
+    user_email = auth[0]
+
+    # Check if group name already exists
+    existing_group = db.query(Group).filter(Group.name == group.name).first()
+    if existing_group:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Group with name '{group.name}' already exists",
+        )
+
+    # Create the group
+    new_group = Group(
+        name=group.name,
+        description=group.description,
+        created_by=user_email,
+    )
+    db.add(new_group)
+    db.flush()
+
+    # Add creator as owner
+    creator_member = GroupMember(
+        group_id=new_group.id,
+        user_email=user_email,
+        role=GroupRole.owner,
+    )
+    db.add(creator_member)
+    db.commit()
+    db.refresh(new_group)
+
+    return new_group
+
+
+@router.get("/", response_model=List[GroupOut])
+async def list_groups(
+    db: Session = Depends(utils.get_db),
+    auth=Depends(auth_handler),
+):
+    """
+    List all groups the current user belongs to.
+
+    Parameters
+    ----------
+    db : Session
+        Database session
+    auth : tuple
+        Authentication tuple (email, token, groups)
+
+    Returns
+    -------
+    List[GroupOut]
+        List of groups the user is a member of
+    """
+    user_email = auth[0]
+
+    groups = (
+        db.query(Group)
+        .join(GroupMember)
+        .filter(GroupMember.user_email == user_email)
+        .all()
+    )
+
+    return groups
+
+
+@router.get("/{group_id}", response_model=GroupOut)
+async def get_group(
+    group_id: UUID,
+    db: Session = Depends(utils.get_db),
+    auth=Depends(auth_handler),
+):
+    """
+    Get group details including members. User must be a member.
+
+    Parameters
+    ----------
+    group_id : UUID
+        The group ID
+    db : Session
+        Database session
+    auth : tuple
+        Authentication tuple (email, token, groups)
+
+    Returns
+    -------
+    GroupOut
+        The group details with members
+    """
+    user_email = auth[0]
+
+    # Verify user is a member
+    _require_group_member(group_id, user_email, db)
+
+    group = db.query(Group).filter(Group.id == group_id).first()
+    if not group:
+        raise HTTPException(status_code=404, detail="Group not found")
+
+    return group
+
+
+@router.delete("/{group_id}", status_code=204)
+async def delete_group(
+    group_id: UUID,
+    db: Session = Depends(utils.get_db),
+    auth=Depends(auth_handler),
+):
+    """
+    Delete a group and all associated data. Must be an owner.
+
+    Parameters
+    ----------
+    group_id : UUID
+        The group ID
+    db : Session
+        Database session
+    auth : tuple
+        Authentication tuple (email, token, groups)
+    """
+    user_email = auth[0]
+
+    # Verify user is an owner
+    _require_group_owner(group_id, user_email, db)
+
+    group = db.query(Group).filter(Group.id == group_id).first()
+    if not group:
+        raise HTTPException(status_code=404, detail="Group not found")
+
+    db.delete(group)
+    db.commit()
+
+
+# ***************************************************
+# Member Management
+# ***************************************************
+@router.post("/{group_id}/members", response_model=GroupOut, status_code=201)
+async def add_member(
+    group_id: UUID,
+    member: GroupMemberAdd,
+    db: Session = Depends(utils.get_db),
+    auth=Depends(auth_handler),
+):
+    """
+    Add a user to the group. Only owners can add members.
+
+    Parameters
+    ----------
+    group_id : UUID
+        The group ID
+    member : GroupMemberAdd
+        Member data to add
+    db : Session
+        Database session
+    auth : tuple
+        Authentication tuple (email, token, groups)
+
+    Returns
+    -------
+    GroupOut
+        The updated group with members
+    """
+    user_email = auth[0]
+
+    # Verify user is an owner
+    _require_group_owner(group_id, user_email, db)
+
+    # Check if group exists
+    group = db.query(Group).filter(Group.id == group_id).first()
+    if not group:
+        raise HTTPException(status_code=404, detail="Group not found")
+
+    # Check if member already exists
+    existing_member = (
+        db.query(GroupMember)
+        .filter(
+            and_(
+                GroupMember.group_id == group_id,
+                GroupMember.user_email == member.user_email,
+            )
+        )
+        .first()
+    )
+    if existing_member:
+        raise HTTPException(
+            status_code=400,
+            detail=f"User {member.user_email} is already a member of this group",
+        )
+
+    # Add new member
+    new_member = GroupMember(
+        group_id=group_id,
+        user_email=member.user_email,
+        role=member.role,
+    )
+    db.add(new_member)
+    db.commit()
+    db.refresh(group)
+
+    return group
+
+
+@router.delete("/{group_id}/members/{user_email}", status_code=204)
+async def remove_member(
+    group_id: UUID,
+    user_email: str,
+    db: Session = Depends(utils.get_db),
+    auth=Depends(auth_handler),
+):
+    """
+    Remove a member from the group.
+    Owners can remove anyone; members can remove themselves.
+
+    Parameters
+    ----------
+    group_id : UUID
+        The group ID
+    user_email : str
+        Email of the user to remove
+    db : Session
+        Database session
+    auth : tuple
+        Authentication tuple (email, token, groups)
+    """
+    current_user_email = auth[0]
+
+    # Get the member to be removed
+    member_to_remove = (
+        db.query(GroupMember)
+        .filter(
+            and_(
+                GroupMember.group_id == group_id,
+                GroupMember.user_email == user_email,
+            )
+        )
+        .first()
+    )
+
+    if not member_to_remove:
+        raise HTTPException(status_code=404, detail="Member not found in this group")
+
+    # Check permissions: must be owner or removing self
+    current_member = (
+        db.query(GroupMember)
+        .filter(
+            and_(
+                GroupMember.group_id == group_id,
+                GroupMember.user_email == current_user_email,
+            )
+        )
+        .first()
+    )
+
+    if not current_member:
+        raise HTTPException(
+            status_code=403,
+            detail="You must be a member of this group to perform this action",
+        )
+
+    # Allow if user is owner OR removing themselves
+    if current_member.role != GroupRole.owner and user_email != current_user_email:
+        raise HTTPException(
+            status_code=403,
+            detail="Only group owners can remove other members",
+        )
+
+    db.delete(member_to_remove)
+    db.commit()
+
+
+@router.put("/{group_id}/members/{user_email}/role", response_model=GroupOut)
+async def update_member_role(
+    group_id: UUID,
+    user_email: str,
+    role_update: MemberRoleUpdate,
+    db: Session = Depends(utils.get_db),
+    auth=Depends(auth_handler),
+):
+    """
+    Update a member's role. Only owners can update roles.
+    Cannot demote the last remaining owner.
+
+    Parameters
+    ----------
+    group_id : UUID
+        The group ID
+    user_email : str
+        Email of the user whose role to update
+    role_update : MemberRoleUpdate
+        New role data
+    db : Session
+        Database session
+    auth : tuple
+        Authentication tuple (email, token, groups)
+
+    Returns
+    -------
+    GroupOut
+        The updated group with members
+    """
+    current_user_email = auth[0]
+
+    # Verify current user is an owner
+    _require_group_owner(group_id, current_user_email, db)
+
+    # Get the member to update
+    member = (
+        db.query(GroupMember)
+        .filter(
+            and_(
+                GroupMember.group_id == group_id,
+                GroupMember.user_email == user_email,
+            )
+        )
+        .first()
+    )
+
+    if not member:
+        raise HTTPException(status_code=404, detail="Member not found in this group")
+
+    # If demoting from owner to member, check if this is the last owner
+    if member.role == GroupRole.owner and role_update.role == GroupRole.member:
+        owner_count = (
+            db.query(func.count(GroupMember.user_email))
+            .filter(
+                and_(
+                    GroupMember.group_id == group_id,
+                    GroupMember.role == GroupRole.owner,
+                    GroupMember.user_email != user_email,
+                )
+            )
+            .scalar()
+        )
+
+        if owner_count == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot demote the last owner. Promote another member to owner first.",
+            )
+
+    # Update the role
+    member.role = role_update.role
+    db.commit()
+
+    # Refresh and return the group
+    group = db.query(Group).filter(Group.id == group_id).first()
+    db.refresh(group)
+
+    return group
+
+
+# ***************************************************
+# Artifact Permissions
+# ***************************************************
+@router.get("/{group_id}/artifacts", response_model=List[ArtifactPermissionOut])
+async def list_group_artifacts(
+    group_id: UUID,
+    db: Session = Depends(utils.get_db),
+    auth=Depends(auth_handler),
+):
+    """
+    List all artifacts shared with this group. User must be a member.
+
+    Parameters
+    ----------
+    group_id : UUID
+        The group ID
+    db : Session
+        Database session
+    auth : tuple
+        Authentication tuple (email, token, groups)
+
+    Returns
+    -------
+    List[ArtifactPermissionOut]
+        List of artifact permissions for this group
+    """
+    user_email = auth[0]
+
+    # Verify user is a member
+    _require_group_member(group_id, user_email, db)
+
+    permissions = (
+        db.query(ArtifactPermission)
+        .filter(ArtifactPermission.group_id == group_id)
+        .all()
+    )
+
+    return permissions
+
+
+@router.post(
+    "/{group_id}/artifacts", response_model=ArtifactPermissionOut, status_code=201
+)
+async def grant_artifact_permission(
+    group_id: UUID,
+    permission: ArtifactPermissionGrant,
+    db: Session = Depends(utils.get_db),
+    auth=Depends(auth_handler),
+):
+    """
+    Share an artifact with the group. The caller must own the artifact.
+    Only owners can share artifacts.
+
+    Parameters
+    ----------
+    group_id : UUID
+        The group ID
+    permission : ArtifactPermissionGrant
+        Artifact permission data
+    db : Session
+        Database session
+    auth : tuple
+        Authentication tuple (email, token, groups)
+
+    Returns
+    -------
+    ArtifactPermissionOut
+        The created artifact permission
+    """
+    user_email = auth[0]
+
+    # Verify user is an owner
+    _require_group_owner(group_id, user_email, db)
+
+    # Verify group exists
+    group = db.query(Group).filter(Group.id == group_id).first()
+    if not group:
+        raise HTTPException(status_code=404, detail="Group not found")
+
+    # Get the model class for this artifact type
+    model_class = ARTIFACT_TYPE_TO_MODEL.get(permission.artifact_type)
+    if not model_class:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid artifact type: {permission.artifact_type}",
+        )
+
+    # Verify artifact exists and is owned by current user
+    artifact = (
+        db.query(model_class).filter(model_class.id == permission.artifact_id).first()
+    )
+
+    if not artifact:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Artifact not found: {permission.artifact_type} with id {permission.artifact_id}",
+        )
+
+    # Check ownership - artifact must be created by current user
+    if hasattr(artifact, "created_by") and artifact.created_by != user_email:
+        raise HTTPException(
+            status_code=403,
+            detail="You can only share artifacts that you own",
+        )
+
+    # Check if permission already exists
+    existing_permission = (
+        db.query(ArtifactPermission)
+        .filter(
+            and_(
+                ArtifactPermission.group_id == group_id,
+                ArtifactPermission.artifact_type == permission.artifact_type,
+                ArtifactPermission.artifact_id == permission.artifact_id,
+            )
+        )
+        .first()
+    )
+
+    if existing_permission:
+        raise HTTPException(
+            status_code=400,
+            detail="This artifact is already shared with this group",
+        )
+
+    # Create the permission
+    new_permission = ArtifactPermission(
+        group_id=group_id,
+        artifact_type=permission.artifact_type,
+        artifact_id=permission.artifact_id,
+        granted_by=user_email,
+    )
+    db.add(new_permission)
+    db.commit()
+    db.refresh(new_permission)
+
+    return new_permission
+
+
+@router.delete("/{group_id}/artifacts/{artifact_type}/{artifact_id}", status_code=204)
+async def revoke_artifact_permission(
+    group_id: UUID,
+    artifact_type: ArtifactType,
+    artifact_id: UUID,
+    db: Session = Depends(utils.get_db),
+    auth=Depends(auth_handler),
+):
+    """
+    Revoke a group's access to an artifact. Only owners can revoke access.
+
+    Parameters
+    ----------
+    group_id : UUID
+        The group ID
+    artifact_type : ArtifactType
+        The type of artifact
+    artifact_id : UUID
+        The artifact ID
+    db : Session
+        Database session
+    auth : tuple
+        Authentication tuple (email, token, groups)
+    """
+    user_email = auth[0]
+
+    # Verify user is an owner
+    _require_group_owner(group_id, user_email, db)
+
+    # Find the permission
+    permission = (
+        db.query(ArtifactPermission)
+        .filter(
+            and_(
+                ArtifactPermission.group_id == group_id,
+                ArtifactPermission.artifact_type == artifact_type,
+                ArtifactPermission.artifact_id == artifact_id,
+            )
+        )
+        .first()
+    )
+
+    if not permission:
+        raise HTTPException(
+            status_code=404,
+            detail="Artifact permission not found",
+        )
+
+    db.delete(permission)
+    db.commit()
+
+
+# Made with Bob

--- a/gfmstudio/groups/models.py
+++ b/gfmstudio/groups/models.py
@@ -1,0 +1,125 @@
+# © Copyright IBM Corporation 2025
+# SPDX-License-Identifier: Apache-2.0
+
+
+import enum
+import uuid
+
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from gfmstudio.common.db import Base
+
+
+class GroupRole(str, enum.Enum):
+    """Enum for group member roles."""
+
+    owner = "owner"
+    member = "member"
+
+
+class ArtifactType(str, enum.Enum):
+    """Enum for artifact types that can be shared with groups."""
+
+    dataset = "dataset"
+    tune = "tune"
+    backbone = "backbone"
+    model = "model"
+    task_template = "task_template"
+    inference_run = "inference_run"
+
+
+class Group(Base):
+    """Group model for team-based artifact sharing."""
+
+    __tablename__ = "groups"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String(255), unique=True, nullable=False)
+    description = Column(Text, nullable=True)
+    created_by = Column(String(255), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    # Relationships
+    members = relationship(
+        "GroupMember",
+        back_populates="group",
+        cascade="all, delete-orphan",
+        lazy="joined",
+    )
+    permissions = relationship(
+        "ArtifactPermission",
+        back_populates="group",
+        cascade="all, delete-orphan",
+        lazy="select",
+    )
+
+    def __str__(self):
+        return f"Group(id={self.id}, name={self.name})"
+
+
+class GroupMember(Base):
+    """Group membership model linking users to groups with roles."""
+
+    __tablename__ = "group_members"
+
+    group_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("groups.id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+    user_email = Column(String(255), primary_key=True, nullable=False)
+    role = Column(
+        Enum(GroupRole, name="group_role"),
+        nullable=False,
+        server_default="member",
+    )
+    added_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    # Relationships
+    group = relationship("Group", back_populates="members")
+
+    def __str__(self):
+        return f"GroupMember(group_id={self.group_id}, user={self.user_email}, role={self.role})"
+
+
+class ArtifactPermission(Base):
+    """Artifact permission model tracking which artifacts are shared with which groups."""
+
+    __tablename__ = "artifact_permissions"
+
+    group_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("groups.id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+    artifact_type = Column(
+        Enum(ArtifactType, name="artifact_type_enum"),
+        primary_key=True,
+        nullable=False,
+    )
+    artifact_id = Column(UUID(as_uuid=True), primary_key=True, nullable=False)
+    granted_by = Column(String(255), nullable=False)
+    granted_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    # Relationships
+    group = relationship("Group", back_populates="permissions")
+
+    def __str__(self):
+        return (
+            f"ArtifactPermission(group_id={self.group_id}, "
+            f"type={self.artifact_type}, artifact_id={self.artifact_id})"
+        )
+
+
+# Made with Bob

--- a/gfmstudio/groups/schemas.py
+++ b/gfmstudio/groups/schemas.py
@@ -1,0 +1,76 @@
+# © Copyright IBM Corporation 2025
+# SPDX-License-Identifier: Apache-2.0
+
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from gfmstudio.groups.models import ArtifactType, GroupRole
+
+
+class GroupCreate(BaseModel):
+    """Schema for creating a new group."""
+
+    name: str
+    description: Optional[str] = None
+
+
+class GroupMemberAdd(BaseModel):
+    """Schema for adding a member to a group."""
+
+    user_email: str
+    role: GroupRole = GroupRole.member
+
+
+class MemberRoleUpdate(BaseModel):
+    """Schema for updating a member's role."""
+
+    role: GroupRole
+
+
+class ArtifactPermissionGrant(BaseModel):
+    """Schema for granting artifact access to a group."""
+
+    artifact_type: ArtifactType
+    artifact_id: UUID
+
+
+class MemberOut(BaseModel):
+    """Schema for group member response."""
+
+    user_email: str
+    role: GroupRole
+    added_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ArtifactPermissionOut(BaseModel):
+    """Schema for artifact permission response."""
+
+    group_id: UUID
+    artifact_type: ArtifactType
+    artifact_id: UUID
+    granted_by: str
+    granted_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class GroupOut(BaseModel):
+    """Schema for group response."""
+
+    id: UUID
+    name: str
+    description: Optional[str]
+    created_by: str
+    created_at: datetime
+    members: list[MemberOut] = []
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# Made with Bob

--- a/gfmstudio/groups/visibility.py
+++ b/gfmstudio/groups/visibility.py
@@ -1,0 +1,75 @@
+# © Copyright IBM Corporation 2025
+# SPDX-License-Identifier: Apache-2.0
+
+
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from gfmstudio.config import settings
+from gfmstudio.groups.models import ArtifactPermission, ArtifactType, GroupMember
+
+
+def build_visibility_filter(
+    model_class, user_email: str, artifact_type: ArtifactType, db: Session
+):
+    """
+    Build a SQLAlchemy filter clause for artifact visibility.
+
+    An artifact is visible to a user if any of the following conditions are true:
+    1. The user owns the artifact (created_by == user_email)
+    2. The artifact is system-wide (created_by == system@ibm.com)
+    3. The artifact is shared with a group the user belongs to
+
+    Parameters
+    ----------
+    model_class : Type
+        The SQLAlchemy model class for the artifact (e.g., Tunes, GeoDataset, Model)
+    user_email : str
+        The email of the current user
+    artifact_type : ArtifactType
+        The type of artifact being queried
+    db : Session
+        Database session
+
+    Returns
+    -------
+    BinaryExpression
+        A SQLAlchemy or_() clause that can be used in a filter
+
+    Examples
+    --------
+    >>> from gfmstudio.fine_tuning.models import Tunes
+    >>> from gfmstudio.groups.models import ArtifactType
+    >>> filter_clause = build_visibility_filter(Tunes, "user@example.com", ArtifactType.tune, db)
+    >>> tunes = db.query(Tunes).filter(filter_clause).all()
+    """
+    # Subquery to get artifact IDs shared with groups the user belongs to
+    # This finds all artifact_ids of the given type that are shared with
+    # any group where the user is a member
+    shared_artifacts_subquery = (
+        select(ArtifactPermission.artifact_id)
+        .join(
+            GroupMember,
+            GroupMember.group_id == ArtifactPermission.group_id,
+        )
+        .where(
+            GroupMember.user_email == user_email,
+            ArtifactPermission.artifact_type == artifact_type,
+        )
+        .scalar_subquery()
+    )
+
+    # Build the visibility filter with three conditions
+    visibility_filter = or_(
+        # Condition 1: User owns the artifact
+        model_class.created_by == user_email,
+        # Condition 2: Artifact is system-wide
+        model_class.created_by == settings.DEFAULT_SYSTEM_USER,
+        # Condition 3: Artifact is shared with a group the user belongs to
+        model_class.id.in_(shared_artifacts_subquery),
+    )
+
+    return visibility_filter
+
+
+# Made with Bob

--- a/gfmstudio/inference/v2/api.py
+++ b/gfmstudio/inference/v2/api.py
@@ -24,11 +24,14 @@ from fastapi import (
 )
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
-from sqlalchemy import and_
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 from sse_starlette import EventSourceResponse
 from terrakit import DataConnector
 from terrakit.download.geodata_utils import list_data_connectors
+
+from gfmstudio.groups.models import ArtifactType
+from gfmstudio.groups.visibility import build_visibility_filter
 
 from gfmstudio.amo.schemas import OnboardModelRequest
 from gfmstudio.auth.authorizer import auth_handler
@@ -246,14 +249,19 @@ async def list_models(
     search_filters = {}
     if internal_name:
         search_filters["internal_name"] = internal_name
+    
+    # Apply group-based visibility filter
+    visibility_filter = build_visibility_filter(Model, user, ArtifactType.model, db)
+    
     count, items = model_crud.get_all(
         db=db,
         limit=limit,
         skip=skip,
         search=search_filters,
         user=user,
-        shared=True,
         filters=filters,
+        filter_expr=visibility_filter,
+        ignore_user_check=True,
         total_count=True,
     )
     return {"results": items, "total_records": count}
@@ -270,7 +278,9 @@ async def get_model(
     auth=Depends(auth_handler),
 ):
     user = auth[0]
-    item = model_crud.get_by_id(db, model_id, user=user)
+    # Check visibility using group-based filter
+    visibility_filter = build_visibility_filter(Model, user, ArtifactType.model, db)
+    item = db.query(Model).filter(and_(Model.id == model_id, visibility_filter)).first()
     if not item:
         raise HTTPException(status_code=404, detail="Model not found")
 
@@ -532,7 +542,6 @@ async def list_inferences(
 ):
     user = auth[0]
     filters = {}
-    filter_expr = None
     filter_expr_list = []
     if location:
         filters["location"] = location
@@ -546,8 +555,12 @@ async def list_inferences(
         filter_expr_list.append(
             Inference.inference_config["fine_tuning_id"].astext == str(tune_id).lower()
         )
-    if filter_expr_list:
-        filter_expr = and_(*filter_expr_list)
+    
+    # Apply group-based visibility filter
+    visibility_filter = build_visibility_filter(Inference, user, ArtifactType.inference_run, db)
+    filter_expr_list.append(visibility_filter)
+    
+    filter_expr = and_(*filter_expr_list) if filter_expr_list else None
 
     count, items = inference_crud.get_all(
         db=db,
@@ -556,6 +569,7 @@ async def list_inferences(
         user=user,
         filters=filters,
         filter_expr=filter_expr,
+        ignore_user_check=True,
         total_count=True,
     )
     return {"results": items, "total_records": count}
@@ -572,7 +586,9 @@ async def retrieve_inference(
     auth=Depends(auth_handler),
 ):
     user = auth[0]
-    item = inference_crud.get_by_id(db, inference_id, user=user)
+    # Check visibility using group-based filter
+    visibility_filter = build_visibility_filter(Inference, user, ArtifactType.inference_run, db)
+    item = db.query(Inference).filter(and_(Inference.id == inference_id, visibility_filter)).first()
     if not item:
         raise HTTPException(status_code=404, detail="Inference not found")
 

--- a/gfmstudio/main.py
+++ b/gfmstudio/main.py
@@ -20,6 +20,7 @@ from gfmstudio.common.api import healthz
 from gfmstudio.config import settings
 from gfmstudio.cos_client import init_cos_client
 from gfmstudio.fine_tuning import api as geoft_apis
+from gfmstudio.groups.api import router as groups_router
 from gfmstudio.inference.v2 import api as inference_apiv2
 from gfmstudio.jira import jira_apis
 from gfmstudio.log import logger
@@ -204,6 +205,7 @@ app.include_router(healthz.router, prefix="/health", tags=["Health"])
 # api_router.include_router(api_events.events_router)
 
 app.include_router(auth_routes.router, prefix="/v2")
+app.include_router(groups_router, prefix="/v2")
 app.include_router(inference_apiv2.router, prefix="/v2")
 app.include_router(geoft_apis.app, prefix="/v2")
 app.include_router(amo_apis.app, prefix="/v2")


### PR DESCRIPTION
## Summary

This PR implements a group-based artifact sharing system that allows users to create groups, manage members, and share various artifacts (datasets, tunes, models, backbones, task templates, and inference runs) with team members. The implementation replaces the previous `shared` flag approach with a more robust permission model based on group memberships.

**Key Changes:**
- Added new `groups` module with database models, API endpoints, and visibility logic
- Created database migration for groups, group members, and artifact permissions tables
- Refactored artifact listing/retrieval endpoints across fine-tuning and inference APIs to use group-based visibility filters
- Artifacts are now visible to users if they: own it, it's system-wide, or it's shared with a group they belong to

## Related Issue (optional)

<!-- e.g. Fixes #123 -->

## How to test this PR?

### Prerequisites
1. Run the database migration:
   ```bash
   alembic upgrade head
   ```

### Testing Group Management
1. **Create a group:**
   ```bash
   POST /v2/groups
   {
     "name": "My Team",
     "description": "Team for ML experiments"
   }
   ```

2. **Add members to the group:**
   ```bash
   POST /v2/groups/{group_id}/members
   {
     "user_email": "teammate@example.com",
     "role": "member"
   }
   ```

3. **List user's groups:**
   ```bash
   GET /v2/groups
   ```

### Testing Artifact Sharing
1. **Share an artifact with a group:**
   ```bash
   POST /v2/groups/{group_id}/artifacts
   {
     "artifact_type": "tune",
     "artifact_id": "{tune_id}"
   }
   ```

2. **Verify visibility:**
   - List tunes/models/datasets as a group member
   - Confirm shared artifacts appear in the results
   - Verify non-members cannot see the shared artifacts

3. **Revoke access:**
   ```bash
   DELETE /v2/groups/{group_id}/artifacts/{artifact_type}/{artifact_id}
   ```

### Testing Visibility Filters
- Create artifacts as different users
- Share artifacts with groups
- Verify that listing endpoints (tunes, models, datasets, etc.) only return:
  - User's own artifacts
  - System artifacts (created by system@ibm.com)
  - Artifacts shared with groups the user belongs to

## Screenshots / Logs (optional)

<!-- Attach any relevant logs or screenshots. -->

## Checklist

- [ ] This PR targets the main branch
- [ ] I have added or updated relevant docs.
- [ ] I have not included any secrets or credentials.
- [ ] Linting and formatting checks pass.