### PR TITLE
Config to add security context to onboarding dataset job

### DIFF
--- a/gfmstudio/config.py
+++ b/gfmstudio/config.py
@@ -295,6 +295,7 @@ class Settings(BaseSettings):
     model_config = ConfigDict(
         extra="allow", case_sensitive=True, env_file=os.path.join(BASE_DIR, ".env")
     )
+    APPEND_SECURITY_CONTEXT: Optional[str] = Field(default="false")
 
     ####################
     # AMO

--- a/gfmstudio/config.py
+++ b/gfmstudio/config.py
@@ -296,6 +296,7 @@ class Settings(BaseSettings):
         extra="allow", case_sensitive=True, env_file=os.path.join(BASE_DIR, ".env")
     )
     APPEND_SECURITY_CONTEXT: Optional[str] = Field(default="false")
+    SECURITY_CONTEXT_FSGROUP: Optional[str] = Field(default="1000")
 
     ####################
     # AMO

--- a/gfmstudio/fine_tuning/api.py
+++ b/gfmstudio/fine_tuning/api.py
@@ -2411,7 +2411,7 @@ async def onboard_dataset(
             add_security_context_command = (
                 f"sed -i '/serviceAccountName: api-gateway-sa/a\\"
                 f"      securityContext:\\n"
-                f"        fsGroup: 1000\\n"
+                f"        fsGroup: {settings.SECURITY_CONTEXT_FSGROUP}\\n"
                 f"        fsGroupChangePolicy: \"OnRootMismatch\"' "
                 f"{kjob_tpl}"
             )

--- a/gfmstudio/fine_tuning/api.py
+++ b/gfmstudio/fine_tuning/api.py
@@ -2405,6 +2405,21 @@ async def onboard_dataset(
             create_job_deployment_file_command, shell=True
         )
         logger.info("Job deployment file created " + str(create_deployment_file_output))
+
+        # Add security context for job deployments
+        if settings.APPEND_SECURITY_CONTEXT and settings.APPEND_SECURITY_CONTEXT.lower() == "true":
+            add_security_context_command = (
+                f"sed -i '/serviceAccountName: api-gateway-sa/a\\"
+                f"      securityContext:\\n"
+                f"        fsGroup: 1000\\n"
+                f"        fsGroupChangePolicy: \"OnRootMismatch\"' "
+                f"{kjob_tpl}"
+            )
+            security_context_output = subprocess.check_output(
+                add_security_context_command, shell=True
+            )
+            logger.info("Security context added for job: " + str(security_context_output))
+
         replace_id_output = subprocess.check_output(
             replace_dataset_id_command, shell=True
         )


### PR DESCRIPTION
## Summary

Allow user to add security context

Using the env vars
```
APPEND_SECURITY_CONTEXT - true/false
SECURITY_CONTEXT_FSGROUP - user-supplied e.g. 1000, 10001, etc
```

This is useful for eks environment

## How to test this PR?

- When env vars are not set; normal running a dataset onboard should be fine (No security context)
- When env vars are supplied the security context should be set in the job yaml


## Checklist

- [x] This PR targets the main branch
- [x] I have added or updated relevant docs.
- [x] I have not included any secrets or credentials.
- [x] Linting and formatting checks pass.
