### PR TITLE
chore: :wrench: add security context to tuning job

### DIFF
--- a/gfmstudio/fine_tuning/core/kubernetes.py
+++ b/gfmstudio/fine_tuning/core/kubernetes.py
@@ -383,6 +383,8 @@ async def deploy_tuning_job(
             str(settings.RESOURCE_REQUEST_Memory),
             str(settings.RESOURCE_REQUEST_GPU),
             str(settings.RUN_TERRATORCH_TEST),
+            str(settings.APPEND_SECURITY_CONTEXT),
+            str(settings.SECURITY_CONTEXT_FSGROUP),
         ]
         logger.info(f"Executing command: {command}")
 

--- a/gfmstudio/fine_tuning/deployment/scripts/run_geoft_job.sh
+++ b/gfmstudio/fine_tuning/deployment/scripts/run_geoft_job.sh
@@ -50,6 +50,8 @@ export RESOURCE_REQUEST_Memory=${14:-24}
 export RESOURCE_REQUEST_GPU=${15:-1}
 export RUN_TERRATORCH_TEST=${16}
 export NODE_AFFINITY=${17}
+export APPEND_SECURITY_CONTEXT=${18:-false}
+export SECURITY_CONTEXT_FSGROUP=${19:-2000}
 
 # Replace the variable and properly indent the content
 sed '/\${TUNING_CONFIG_YAML}/{
@@ -67,6 +69,12 @@ if [ -z "$IMAGE_PULL_SECRET" ]; then
     echo "IMAGE_PULL_SECRET is empty, removing imagePullSecrets from manifest"
     # Remove the imagePullSecrets section (handles both single-line and multi-line formats)
     sed -i '/imagePullSecrets:/,/^[^ ]/{ /imagePullSecrets:/d; /- name:/d; /^[^ ]/!d; }' "/tmp/$output_manifest_yaml"
+fi
+
+# Add security context if APPEND_SECURITY_CONTEXT is true
+if [ "$APPEND_SECURITY_CONTEXT" = "true" ] || [ "$APPEND_SECURITY_CONTEXT" = "True" ]; then
+    echo "Adding pod security context with fsGroup: $SECURITY_CONTEXT_FSGROUP"
+    sed -i '/serviceAccountName: api-gateway-sa/a\      securityContext:\n        fsGroup: '"$SECURITY_CONTEXT_FSGROUP"'\n        fsGroupChangePolicy: "OnRootMismatch"' "/tmp/$output_manifest_yaml"
 fi
 
 # kubectl apply --dry-run=client -f "/tmp/$output_manifest_yaml"

--- a/gfmstudio/fine_tuning/deployment/scripts/run_geoft_job.sh
+++ b/gfmstudio/fine_tuning/deployment/scripts/run_geoft_job.sh
@@ -49,9 +49,9 @@ export RESOURCE_REQUEST_CPU=${13:-6}
 export RESOURCE_REQUEST_Memory=${14:-24}
 export RESOURCE_REQUEST_GPU=${15:-1}
 export RUN_TERRATORCH_TEST=${16}
-export NODE_AFFINITY=${17}
-export APPEND_SECURITY_CONTEXT=${18:-false}
-export SECURITY_CONTEXT_FSGROUP=${19:-2000}
+export APPEND_SECURITY_CONTEXT=${17:-false}
+export SECURITY_CONTEXT_FSGROUP=${18:-2000}
+export NODE_AFFINITY=${19}
 
 # Replace the variable and properly indent the content
 sed '/\${TUNING_CONFIG_YAML}/{


### PR DESCRIPTION
## Summary

Allow user to add security context

Using the env vars
```
APPEND_SECURITY_CONTEXT - true/false
SECURITY_CONTEXT_FSGROUP - user-supplied e.g. 1000, 10001, etc
```

This is useful for eks environment

## How to test this PR?

- When env vars are not set; normal running tuning (No security context)
- When env vars are supplied the security context should be set in the job yaml


## Checklist

- [x] This PR targets the main branch
- [x] I have added or updated relevant docs.
- [x] I have not included any secrets or credentials.
- [x] Linting and formatting checks pass.
